### PR TITLE
Set text/plain for 204 resposne

### DIFF
--- a/src/controllers/API.js
+++ b/src/controllers/API.js
@@ -179,6 +179,8 @@ class APIController {
           response.primary, response.included,
           undefined, registry.urlTemplates(), request.uri
         ).get(true);
+      } else {
+        response.contentType = "text/plain";
       }
 
       return response;


### PR DESCRIPTION
There is no JSON body in the response. The dredd / apiary.io test
runner complains about the content type being set on
